### PR TITLE
NewsScheduler try-catch 문으로 예외 처리, WebDriverPool 모니터링 및 초기화 기능 추가

### DIFF
--- a/innuce/src/main/java/com/mc/innuce/domain/news/controller/NewsController.java
+++ b/innuce/src/main/java/com/mc/innuce/domain/news/controller/NewsController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
 
 import com.mc.innuce.domain.news.dto.NewsDTO;
+import com.mc.innuce.domain.news.selenium.webdriver.WebDriverPool;
 import com.mc.innuce.domain.news.service.NewsService;
 
 @RestController
@@ -19,6 +20,8 @@ public class NewsController {
 
 	@Autowired
 	NewsService ns;
+	@Autowired
+	WebDriverPool pool;
 	
 	@GetMapping("headline")
 	@ResponseBody
@@ -58,5 +61,15 @@ public class NewsController {
 			WebDriver driver = new ChromeDriver(chromeOptions);
 			driver.quit();
 		}
+	}
+	
+	@GetMapping("/testshowdriver")
+	public void showPool() {
+		pool.showStatusWebDriverPool();
+	}
+	
+	@GetMapping("/testinitpool")
+	public void initPool() {
+		pool.initWebDriverPool();
 	}
 }

--- a/innuce/src/main/java/com/mc/innuce/domain/news/selenium/service/CrawlingNewsService.java
+++ b/innuce/src/main/java/com/mc/innuce/domain/news/selenium/service/CrawlingNewsService.java
@@ -435,7 +435,7 @@ public class CrawlingNewsService {
 	public NewsDTO parseNewsToNewsDTO(WebDriver newsdriver, String href, String thumbnailuri) {
 		NewsDTO news = new NewsDTO();
 		newsdriver.get(href);
-		System.out.println(href);
+		
 		news.setNews_key(conv.getLongNewsKey(href));
 		news.setPress_key(conv.getIntPressKey(href));
 		news.setNews_title(newsdriver.findElement(By.id("title_area")).getText());

--- a/innuce/src/main/java/com/mc/innuce/domain/news/selenium/webdriver/WebDriverPool.java
+++ b/innuce/src/main/java/com/mc/innuce/domain/news/selenium/webdriver/WebDriverPool.java
@@ -1,5 +1,6 @@
 package com.mc.innuce.domain.news.selenium.webdriver;
 
+import java.util.ArrayList;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
@@ -75,7 +76,53 @@ public class WebDriverPool {
 	}
 
 	public static void releaseWebDriver(WebDriver webDriver) {
-		webDriverPool.offer(webDriver);
+		if(webDriverPool.size() < MAX_POOL_SIZE)
+			webDriverPool.offer(webDriver);
+		else
+			webDriver.quit();
 	}
 
+	public void showStatusWebDriverPool() {
+		System.out.println("WebDriverPool have " + webDriverPool.size());
+		
+		ArrayList<WebDriver> list = new ArrayList<>();
+		
+		int size = webDriverPool.size();
+		for(int i = 0; i <size; i++) {
+			try {
+				list.add(webDriverPool.take());
+				System.out.println("take");
+			} catch (Exception e) {
+				System.out.println("releaseWebDriver ERROR");
+				e.printStackTrace();
+			}
+		}
+		
+		System.out.println("WebDriverList have " + list.size());
+		for(WebDriver driver : list) {
+			System.out.println("currenturl" + driver.getCurrentUrl());
+			releaseWebDriver(driver);
+		}
+	}
+	
+	public void initWebDriverPool() {
+		System.out.println("init driverpool");
+		System.out.println("size " + webDriverPool.size());
+		while(webDriverPool.size() > 0) {
+			try {
+				webDriverPool.take().quit();
+				System.out.println("size " + webDriverPool.size());
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+		
+		
+		for(int i = 0; i < MAX_POOL_SIZE; i++) {
+			System.out.println("creating...");
+			webDriverPool.offer(createNewWebDriver());
+			System.out.println(webDriverPool.size());
+		}
+		
+	}
 }

--- a/innuce/src/main/java/com/mc/innuce/global/scheduler/NewsScheduler.java
+++ b/innuce/src/main/java/com/mc/innuce/global/scheduler/NewsScheduler.java
@@ -1,10 +1,12 @@
 package com.mc.innuce.global.scheduler;
 
+import org.openqa.selenium.WebDriver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.mc.innuce.domain.news.selenium.service.CrawlingNewsService;
+import com.mc.innuce.domain.news.selenium.webdriver.WebDriverPool;
 import com.mc.innuce.domain.news.service.NewsService;
 import com.mc.innuce.global.config.Config;
 
@@ -15,6 +17,8 @@ public class NewsScheduler {
 	NewsService ns;
 	@Autowired
 	CrawlingNewsService cns;
+	@Autowired
+	WebDriverPool pool;
 	
 	private boolean isCategoryCrawlerRunning = false; // default false !
 	private boolean isHeadlineCrawlerRunning = false; // default false !
@@ -25,35 +29,53 @@ public class NewsScheduler {
 	@Scheduled(cron = "0 0/20 * * * *")
 	public void schduleUpdateNewsCategory() {
 		
-//		if (!isCategoryCrawlerRunning) {
-		if (Config.CURRENT_OS.equals("linux") && !isCategoryCrawlerRunning) {
-			System.out.println("categoryCrawlerCallCount : " + ++categoryCrawlerCallCount);
-			System.out.println("category crawller 실행");
-			isCategoryCrawlerRunning = true;
-
-			cns.crawllingCategoryNews();
+		try {
+//			if (!isCategoryCrawlerRunning) {
+			if (Config.CURRENT_OS.equals("linux") && !isCategoryCrawlerRunning) {
+				System.out.println("categoryCrawlerCallCount : " + ++categoryCrawlerCallCount);
+				System.out.println("category crawller 실행");
+				isCategoryCrawlerRunning = true;
+				
+				cns.crawllingCategoryNews();
+				
+				isCategoryCrawlerRunning = false;
+				System.out.println("category crawller 종료");
+			}
 			
-			isCategoryCrawlerRunning = false;
-			System.out.println("category crawller 종료");
+		} catch (Exception e) {
+			System.out.println("schduleUpdateNewsCategory ERROR!!!");
+			pool.showStatusWebDriverPool();
+			pool.initWebDriverPool();
+			e.printStackTrace();
 		}
+		
 	}
 
 	// 한시간 마다 실행
 	@Scheduled(cron = "30 0 * * * *")
 	public void scheduleUpdateNewsHeadline() {
 		
-//		if (!isHeadlineCrawlerRunning) {
-		if (Config.CURRENT_OS.equals("linux") && !isHeadlineCrawlerRunning) {
-			System.out.println("headlineCrawlerCallCount : " + ++headlineCrawlerCallCount);
-			System.out.println("headline crawller 실행");
-			String[] categorys = {"정치", "경제", "사회", "생활", "IT", "세계"};
-			isCategoryCrawlerRunning = true;
+		try {
+//			if (!isHeadlineCrawlerRunning) {
+			if (Config.CURRENT_OS.equals("linux") && !isHeadlineCrawlerRunning) {
+				System.out.println("headlineCrawlerCallCount : " + ++headlineCrawlerCallCount);
+				System.out.println("headline crawller 실행");
+				String[] categorys = {"정치", "경제", "사회", "생활", "IT", "세계"};
+				isCategoryCrawlerRunning = true;
+				
+				for(int i = 0; i < categorys.length; i++)
+					cns.crawlerHeadlineNews(categorys[i], "10" + i);
+				isCategoryCrawlerRunning = false;
+				System.out.println("headline crawller 종료");
+			}
 			
-			for(int i = 0; i < categorys.length; i++)
-				cns.crawlerHeadlineNews(categorys[i], "10" + i);
-			isCategoryCrawlerRunning = false;
-			System.out.println("headline crawller 종료");
+		} catch (Exception e) {
+			System.out.println("scheduleUpdateNewsHeadline ERROR!!!");
+			pool.showStatusWebDriverPool();
+			pool.initWebDriverPool();
+			e.printStackTrace();
 		}
+		
 	}
 	
 }


### PR DESCRIPTION
# 수정
- try-catch 추가로 NewsScheduler 안정성 향상
- WebDriverPool show, init 메소드 추가로 웹에서 모니터링 및 초기화 기능 추가